### PR TITLE
Add more module options & apps

### DIFF
--- a/nixinate/default.nix
+++ b/nixinate/default.nix
@@ -10,8 +10,7 @@ let
   generateApps = import ./generate-apps.nix inputs.nixpkgs;
 in
 {
-  flake = {
-  };
+  flake = { };
   perSystem = { system, pkgs, ... }: {
     apps = generateApps pkgs self;
   };

--- a/nixinate/generate-apps.nix
+++ b/nixinate/generate-apps.nix
@@ -22,7 +22,7 @@ in
   #   )
   #   // nixpkgs.lib.genAttrs
   # (map (machineName: a + "-dry-run") validMachines)
-(builtins.concatMap (machine: map (rebuildAction: "${machine}-${rebuildAction}") rebuildActions) validMachines)
+(map (rebuildAction: (map: machineName: (machineName + "-" + rebuildAction) validMachines) ) rebuildActions )
   (x:
   let
     parts = builtins.split "-" x;

--- a/nixinate/generate-apps.nix
+++ b/nixinate/generate-apps.nix
@@ -8,25 +8,31 @@ let
         (flake.nixosConfigurations."${x}".config.deploy.enable) "${x}"));
   mkDeployScript = import ./make-deploy-script.nix { inherit nixpkgs pkgs flake; };
 in
-nixpkgs.lib.genAttrs
-  validMachines
+# nixpkgs.lib.genAttrs
+#   validMachines
+#   (x:
+#     {
+#       type = "app";
+#       program = toString (mkDeployScript {
+#         machine = x;
+#         dryRun = false;
+#       });
+#     }
+#   )
+#   // nixpkgs.lib.genAttrs
+  (map (machineName: a + "-dry-run") validMachines)
+    (builtins.concatMap (machine: map (rebuildAction: "${machine}-${action}") rebuildActions) validMachines)
   (x:
+  let
+      parts = builtins.split "-" x;
+      machineName = builtins.head parts;
+      rebuildAction = builtins.last parts;
+  in
     {
       type = "app";
       program = toString (mkDeployScript {
-        machine = x;
-        dryRun = false;
-      });
-    }
-  )
-  // nixpkgs.lib.genAttrs
-  (map (a: a + "-dry-run") validMachines)
-  (x:
-    {
-      type = "app";
-      program = toString (mkDeployScript {
-        machine = nixpkgs.lib.removeSuffix "-dry-run" x;
-        dryRun = true;
+        machine = machineName;
+        inherit rebuildAction;
       });
     }
   )

--- a/nixinate/generate-apps.nix
+++ b/nixinate/generate-apps.nix
@@ -7,6 +7,7 @@ let
       (x: nixpkgs.lib.optionalString
         (flake.nixosConfigurations."${x}".config.deploy.enable) "${x}"));
   mkDeployScript = import ./make-deploy-script.nix { inherit nixpkgs pkgs flake; };
+    rebuildActions = [ "switch" "boot" "test" "build" "dry-build" "dry-activate" "build-vm" "build-vm-with-bootloader" ];
 in
 # nixpkgs.lib.genAttrs
   #   validMachines

--- a/nixinate/generate-apps.nix
+++ b/nixinate/generate-apps.nix
@@ -9,30 +9,30 @@ let
   mkDeployScript = import ./make-deploy-script.nix { inherit nixpkgs pkgs flake; };
 in
 # nixpkgs.lib.genAttrs
-#   validMachines
-#   (x:
-#     {
-#       type = "app";
-#       program = toString (mkDeployScript {
-#         machine = x;
-#         dryRun = false;
-#       });
-#     }
-#   )
-#   // nixpkgs.lib.genAttrs
-    (builtins.concatMap (machine: map (rebuildAction: "${machine}-${action}") rebuildActions) validMachines)
+  #   validMachines
+  #   (x:
+  #     {
+  #       type = "app";
+  #       program = toString (mkDeployScript {
+  #         machine = x;
+  #         dryRun = false;
+  #       });
+  #     }
+  #   )
+  #   // nixpkgs.lib.genAttrs
   # (map (machineName: a + "-dry-run") validMachines)
+(builtins.concatMap (machine: map (rebuildAction: "${machine}-${action}") rebuildActions) validMachines)
   (x:
   let
-      parts = builtins.split "-" x;
-      machineName = builtins.head parts;
-      rebuildAction = builtins.last parts;
+    parts = builtins.split "-" x;
+    machineName = builtins.head parts;
+    rebuildAction = builtins.last parts;
   in
-    {
-      type = "app";
-      program = toString (mkDeployScript {
-        machine = machineName;
-        inherit rebuildAction;
-      });
-    }
+  {
+    type = "app";
+    program = toString (mkDeployScript {
+      machine = machineName;
+      inherit rebuildAction;
+    });
+  }
   )

--- a/nixinate/generate-apps.nix
+++ b/nixinate/generate-apps.nix
@@ -24,10 +24,10 @@ nixpkgs.lib.genAttrs
   # (map (machineName: a + "-dry-run") validMachines)
 # (builtins.concatMap (rebuildAction: (concatMap: machineName: (machineName + "-" + rebuildAction) validMachines) ) rebuildActions )
 # map validMachines
- (nixpkgs.lib.concatMap (machine: map (action: machine + "-" + action) rebuildActions ) validMachines)
+ (nixpkgs.lib.concatMap (machine: map (action: machine + "_" + action) rebuildActions ) validMachines)
   (x:
   let
-    parts = builtins.split "-" x;
+    parts = builtins.split "_" x;
     machineName = builtins.head parts;
     #ugly, but works. I really can't bother figuring out better ATM
     rebuildAction = builtins.toString (builtins.tail( builtins.tail parts));

--- a/nixinate/generate-apps.nix
+++ b/nixinate/generate-apps.nix
@@ -20,8 +20,8 @@ in
 #     }
 #   )
 #   // nixpkgs.lib.genAttrs
-  (map (machineName: a + "-dry-run") validMachines)
     (builtins.concatMap (machine: map (rebuildAction: "${machine}-${action}") rebuildActions) validMachines)
+  # (map (machineName: a + "-dry-run") validMachines)
   (x:
   let
       parts = builtins.split "-" x;

--- a/nixinate/generate-apps.nix
+++ b/nixinate/generate-apps.nix
@@ -21,7 +21,7 @@ in
   #   )
   #   // nixpkgs.lib.genAttrs
   # (map (machineName: a + "-dry-run") validMachines)
-(builtins.concatMap (machine: map (rebuildAction: "${machine}-${action}") rebuildActions) validMachines)
+(builtins.concatMap (machine: map (rebuildAction: "${machine}-${rebuildAction}") rebuildActions) validMachines)
   (x:
   let
     parts = builtins.split "-" x;

--- a/nixinate/make-deploy-script.nix
+++ b/nixinate/make-deploy-script.nix
@@ -16,7 +16,7 @@ let
   where = n.buildOn or "remote";
   remote = if where == "remote" then true else if where == "local" then false else abort "_module.args.nixinate.buildOn is not set to a valid value of 'local' or 'remote'";
   substituteOnTarget = n.substituteOnTarget or false;
-  switch = if dryRun then "dry-activate" else "switch";
+  # switch = if dryRun then "dry-activate" else "switch";
   nixOptions = concatStringsSep " " (n.nixOptions or [ ]);
 
   script =

--- a/nixinate/make-deploy-script.nix
+++ b/nixinate/make-deploy-script.nix
@@ -9,13 +9,13 @@ let
   openssh = "${getExe pkgs.openssh}";
   flock = "${getExe pkgs.flock}";
 
-  rev = flake.rev or flake.dirtyRev or "unknown";
+  rev = flake.rev or flake.dirtyRev or pkgs.lib.fakeSha1;
   # forceRev = if (hasAttr "rev" flake) then flake.rev 
   #           else if (hasAttr "dirtyRev" flake) then (builtins.head (builtins.split "-dirty"))
   #           else "";
 #  https://github.com/NixOS/nix/blob/0363dbf2b956674d95b8597d2fedd20fc2b529df/src/libfetchers/path.cc#L45
-  targetFlake = "'${flake}?"
-            + optionalString (hasAttr "rev" flake) "&rev=${flake.rev}"
+  targetFlake = "'${flake}?rev=${rev}"
+            # + optionalString (hasAttr "rev" flake) "&rev=${flake.rev}"
             + optionalString (hasAttr "revCount" flake) "&revCount=${toString flake.revCount}"
             + optionalString (hasAttr "lastModified" flake) "&lastModified=${toString flake.lastModified}"
             + optionalString (hasAttr "narHash" flake) "&narHash=${flake.narHash}"

--- a/nixinate/module.nix
+++ b/nixinate/module.nix
@@ -62,5 +62,14 @@ with lib;
         Extra CLI Flags to pass to nixos-rebuild.
       '';
     };
+
+    archiveFlake = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+          Whether the flake and all its inputs should be copied to
+          the remote machine, or just the flake itself.
+      '';
+    };
   };
 }


### PR DESCRIPTION
Hi!
First of all, thanks for remaking nixinate in flake-parts. 

I took your awesome work and made some more options I felt were missing for my personal use. Mainly:
- Allowing to choose whether to perform a switch, boot, dry-rebuild, etc. on the target machine.
- Added a new option to allow the machine where nixinate runs to copy the flake and all its inputs to the target if enabled. (My use-case is that not all my flake inputs are public, and not all machines in my flake have access to those ) 

I'll leave my improvements here in case you're interested in actively maintaining this fork (and also since the original nixinate also hasn't seen any activity in the past 8 months).

If not, please disregard.
Cheers!